### PR TITLE
Add radar chart and question import

### DIFF
--- a/client/src/components/profile/personality-chart.tsx
+++ b/client/src/components/profile/personality-chart.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
 import { getPersonalityColor, formatPercentage } from "@/lib/utils";
 import { t } from "@/lib/i18n";
+import PersonalityRadarChart from "./personality-radar-chart";
 
 interface PersonalityChartProps {
   personalityProfile?: {
@@ -50,6 +51,7 @@ export default function PersonalityChart({ personalityProfile }: PersonalityChar
         <CardTitle>{t("profile.personalityOverview")}</CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
+        <PersonalityRadarChart scores={scores} />
         {Object.entries(scores).map(([trait, score]) => (
           <div key={trait}>
             <div className="flex justify-between items-center mb-2">

--- a/client/src/components/profile/personality-radar-chart.tsx
+++ b/client/src/components/profile/personality-radar-chart.tsx
@@ -1,0 +1,41 @@
+import {
+  RadarChart,
+  PolarGrid,
+  PolarAngleAxis,
+  PolarRadiusAxis,
+  Radar,
+  ResponsiveContainer
+} from "recharts";
+
+interface PersonalityRadarChartProps {
+  scores: {
+    openness: number;
+    conscientiousness: number;
+    extraversion: number;
+    agreeableness: number;
+    neuroticism: number;
+  };
+}
+
+export default function PersonalityRadarChart({ scores }: PersonalityRadarChartProps) {
+  const data = [
+    { trait: "Openness", value: scores.openness },
+    { trait: "Conscientiousness", value: scores.conscientiousness },
+    { trait: "Extraversion", value: scores.extraversion },
+    { trait: "Agreeableness", value: scores.agreeableness },
+    { trait: "Neuroticism", value: scores.neuroticism },
+  ];
+
+  return (
+    <div className="w-full h-64">
+      <ResponsiveContainer>
+        <RadarChart data={data}>
+          <PolarGrid />
+          <PolarAngleAxis dataKey="trait" />
+          <PolarRadiusAxis angle={30} domain={[0, 100]} />
+          <Radar dataKey="value" stroke="#4f46e5" fill="#6366f1" fillOpacity={0.6} />
+        </RadarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/server/openai.ts
+++ b/server/openai.ts
@@ -175,3 +175,51 @@ export async function generateQuestions(topic: string, numQuestions: number): Pr
     throw new Error("Failed to generate questions");
   }
 }
+
+export async function fetchQuestionsFromUrl(url: string, numQuestions: number = 5): Promise<GeneratedQuestion[]> {
+  try {
+    const res = await fetch(url);
+    if (!res.ok) {
+      throw new Error(`Failed to fetch questions: ${res.status} ${res.statusText}`);
+    }
+    const data = await res.json();
+    let questions: GeneratedQuestion[] = [];
+
+    if (Array.isArray(data)) {
+      questions = data.map((item: any) => ({
+        questionText: item.question || item.questionText || "",
+        trait: item.trait || "",
+        options: item.options || [
+          "Strongly Disagree",
+          "Disagree",
+          "Neither Agree nor Disagree",
+          "Agree",
+          "Strongly Agree",
+        ],
+      }));
+    } else if (Array.isArray(data.questions)) {
+      questions = data.questions.map((item: any) => ({
+        questionText: item.question || item.questionText || "",
+        trait: item.trait || "",
+        options: item.options || [
+          "Strongly Disagree",
+          "Disagree",
+          "Neither Agree nor Disagree",
+          "Agree",
+          "Strongly Agree",
+        ],
+      }));
+    } else {
+      throw new Error("Invalid questions format");
+    }
+
+    if (questions.length > numQuestions) {
+      questions = questions.slice(0, numQuestions);
+    }
+
+    return questions;
+  } catch (error) {
+    console.error("Error fetching questions:", error);
+    throw new Error("Failed to fetch questions");
+  }
+}


### PR DESCRIPTION
## Summary
- support importing assessment questions from an external URL
- show personality scores in a radar chart

## Testing
- `npm run check` *(fails: Cannot find type definition file; network blocked)*